### PR TITLE
keep old method signature for backwards compatibility

### DIFF
--- a/core/src/main/java/org/apache/iceberg/actions/RewriteDataFilesCommitManager.java
+++ b/core/src/main/java/org/apache/iceberg/actions/RewriteDataFilesCommitManager.java
@@ -65,6 +65,18 @@ public class RewriteDataFilesCommitManager {
       Table table,
       long startingSnapshotId,
       boolean useStartingSequenceNumber,
+      Map<String, String> snapshotProperties) {
+    this.table = table;
+    this.startingSnapshotId = startingSnapshotId;
+    this.useStartingSequenceNumber = useStartingSequenceNumber;
+    this.snapshotProperties = snapshotProperties;
+    this.targetBranch = SnapshotRef.MAIN_BRANCH;
+  }
+
+  public RewriteDataFilesCommitManager(
+      Table table,
+      long startingSnapshotId,
+      boolean useStartingSequenceNumber,
       Map<String, String> snapshotProperties,
       String branch) {
     this.table = table;


### PR DESCRIPTION
This should fix backward compatibility for RewriteDataFilesCommitManager 